### PR TITLE
(Issue #10) Replace target flag with prod flag

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -28,7 +28,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Compile the site
-        run: python3 compile.py --target prod
+        run: python3 compile.py --prod
 
       - name: Git Auto Commit
         uses: stefanzweifel/git-auto-commit-action@v4.7.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,8 +82,13 @@ pip install -r requirements.txt
 ## Compile and run the site locally
 
 ``` bash
-python compile.py -t dev
+python compile.py
 ```
+
+> If you are building this for Github Pages, use the `--prod` flag to correctly link CSS in the rendered output
+> ```bash
+> python compile.py --prod
+> ```
 
 This will output the HTML and CSS that make up the static site in the `docs` directory.
 

--- a/compile.py
+++ b/compile.py
@@ -14,11 +14,13 @@ import os
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    "-t", "--target", help="The target for compilation ['dev','prod']", required=True
+    "--prod", help="Create github pages compatible format when rendering", required=False, action="store_true"
 )
 
 if __name__ == "__main__":
-    target = parser.parse_args().target
+    target = "dev"
+    if parser.parse_args().prod:
+        target = "prod"
 
     # Read
     recipe_files = glob.glob("./recipes/*.md")


### PR DESCRIPTION
The target flag was misleading as it is commonly used as a flag to
denote the output directory for where to place rendered files.

Instead of having a target flag the flag has been replaced with a
`--prod` flag. Setting this flag will set the target to "prod" and
include github pages links.

Omitting the flag replaces the old behavior of `--target dev` so that by
default the output in the `docs` directory is linked properly without
Github pages format.

This commit addresses Issue #10.